### PR TITLE
JTL resource awareness

### DIFF
--- a/src/main/java/devtools/misc/swgaide.xml
+++ b/src/main/java/devtools/misc/swgaide.xml
@@ -28,12 +28,12 @@
     <opt>-Dsun.java2d.opengl=true</opt>
   </jre>
   <versionInfo>
-    <fileVersion>1.1.9.0</fileVersion>
-    <txtFileVersion>Unity-1.1.9</txtFileVersion>
+    <fileVersion>1.1.10.0</fileVersion>
+    <txtFileVersion>Unity-1.1.10</txtFileVersion>
     <fileDescription>SWGAide-Unity</fileDescription>
     <copyright>swgaide.com 2020</copyright>
-    <productVersion>1.1.9.0</productVersion>
-    <txtProductVersion>Unity-1.1.9</txtProductVersion>
+    <productVersion>1.1.10.0</productVersion>
+    <txtProductVersion>Unity-1.1.10</txtProductVersion>
     <productName>SWGAide-Unity</productName>
     <companyName>swgaide.com</companyName>
     <internalName>SWGAide-Unity</internalName>

--- a/src/main/java/swg/crafting/SWGWeights.java
+++ b/src/main/java/swg/crafting/SWGWeights.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import swg.crafting.resources.SWGResource;
 import swg.crafting.resources.SWGResourceClass;
+import swg.crafting.resources.types.SWGMetal;
 
 /**
  * This type models experimental weights used for crafting in SWG. It also
@@ -246,12 +247,13 @@ public final class SWGWeights extends SWGValues {
      * @param res a resource to rate by this instance
      * @param caps the resource class for upper caps, or {@code null}
      * @param zeroIsMax {@code true} if zero-values are considered
+     * @param useJTLcaps {@code true} if this method should adjust for server-side JTL resource rules
      * @return the resource rate in the range [0.0 1000.0]
      * @throws IllegalArgumentException if the resource class does not match the
      *         specified resource
      * @throws NullPointerException if the resource is {@code null}
      */
-    public double rate(SWGResource res, SWGResourceClass caps, boolean zeroIsMax) {
+    public double rate(SWGResource res, SWGResourceClass caps, boolean zeroIsMax, boolean useJTLcaps) {
         if (caps != null && !res.rc().isSub(caps.getClass()))
             throw new IllegalArgumentException(String.format(
                     "%s is not subclass of %s",
@@ -260,6 +262,9 @@ public final class SWGWeights extends SWGValues {
         if (!hasMinimumOneStat(res))
             return 0.0;
 
+        if (useJTLcaps && caps.isAffectedByJTLcap())
+        	caps = SWGMetal.getInstance();
+        
         // allocating a local copy of these weights in case we have to remove
         // one or more to redistribute without destroying this instance
         double[] weights = new double[Stat.COUNT];

--- a/src/main/java/swg/crafting/resources/ResourceUpdate.java
+++ b/src/main/java/swg/crafting/resources/ResourceUpdate.java
@@ -84,6 +84,15 @@ public final class ResourceUpdate implements UpdateNotification {
          * the specified notification type {@link #optional} must be galaxy
          * constant of type {@link SWGCGalaxy}.
          */
-        NEW_DOWNLOAD;
+        NEW_DOWNLOAD,
+        
+        /**
+         * This reflects a change in how the user wants resource caps to be treated.
+         * When it's true, this app is to use JTL resources as the upper limits for
+         * the impacted resource types. When it's false, it should use the pre-existing
+         * rules for determining resource caps. When this is the specified notification 
+         * type {@link #optional} must be {@link boolean} that shows the new state.
+         */
+        JTL_RESOURCE_CAP;
     }
 }

--- a/src/main/java/swg/crafting/resources/SWGResourceClass.java
+++ b/src/main/java/swg/crafting/resources/SWGResourceClass.java
@@ -10,6 +10,11 @@ import java.util.regex.Pattern;
 
 import devtools.SWGResourceClassGenerator;
 import swg.crafting.Stat;
+import swg.crafting.resources.types.SWGSteel;
+import swg.crafting.resources.types.SWGAluminum;
+import swg.crafting.resources.types.SWGCopper;
+import swg.crafting.resources.types.SWGFerrousMetal;
+import swg.crafting.resources.types.SWGNonFerrousMetal;
 import swg.model.SWGPlanet;
 import swg.tools.ZString;
 
@@ -152,6 +157,19 @@ public abstract class SWGResourceClass implements Serializable,
      */
     public boolean isJTL() {
         return false;
+    }
+
+    /**
+     *
+     * @return {@code true} if this resource class is impacted by the JTL resource
+     * capping rules
+     */
+    public boolean isAffectedByJTLcap() {
+    	return getClass() == SWGSteel.class || 
+    			getClass() == SWGCopper.class || 
+    			getClass() == SWGAluminum.class ||
+    			getClass() == SWGFerrousMetal.class ||
+    			getClass() == SWGNonFerrousMetal.class;
     }
 
     /**

--- a/src/main/java/swg/crafting/resources/SWGResourceSet.java
+++ b/src/main/java/swg/crafting/resources/SWGResourceSet.java
@@ -527,6 +527,9 @@ public final class SWGResourceSet implements Set<SWGKnownResource>,
      * @param zeroIsMax
      *            {@code true} if a zero-value should be treated as its capped
      *            value, otherwise {@code false}
+     * @param useJTLcap
+     *            {@code true} if the resourceSet should adjust weights based on
+     *            JTL resource rules
      * @param threshold
      *            the minimum weight for elements in the returned set, in the
      *            range [0.0 1000.0]
@@ -537,7 +540,7 @@ public final class SWGResourceSet implements Set<SWGKnownResource>,
      *             if any of the object arguments is {@code null}
      */
     public SWGResourceSet subsetBy(SWGWeights weights,
-        SWGResourceClass capsFrom, boolean zeroIsMax, double threshold) {
+        SWGResourceClass capsFrom, boolean zeroIsMax, boolean useJTLcap, double threshold) {
 
         if (threshold > 1000) {
         	threshold = 1000;
@@ -554,7 +557,7 @@ public final class SWGResourceSet implements Set<SWGKnownResource>,
 
         for (SWGKnownResource kr : storage) {
             if (typeCls.isAssignableFrom(kr.rc().getClass())) {
-                double w = weights.rate(kr, capsFrom, zeroIsMax);
+                double w = weights.rate(kr, capsFrom, zeroIsMax, useJTLcap);
                 if (w >= threshold)
                     result.storage.add(kr); // surpass our checkpoints
             }

--- a/src/main/java/swg/crafting/resources/SWGWeightComparator.java
+++ b/src/main/java/swg/crafting/resources/SWGWeightComparator.java
@@ -31,6 +31,11 @@ public class SWGWeightComparator implements Comparator<SWGKnownResource> {
     private final boolean zeroIsMax;
 
     /**
+     * {@code true} if this object should adjust for JTL resource capping rules
+     */
+    private final boolean useJTLcap;
+
+    /**
      * Creates this instance.
      * 
      * @param ws a weight object
@@ -39,15 +44,16 @@ public class SWGWeightComparator implements Comparator<SWGKnownResource> {
      * @param zim {@code true} if zero-values that are in union with the
      *        specified weight should count as upper cap (zero-is-max)
      */
-    public SWGWeightComparator(SWGWeights ws, SWGResourceClass rc, boolean zim) {
+    public SWGWeightComparator(SWGWeights ws, SWGResourceClass rc, boolean zim, boolean useJTLcap) {
         this.weights = ws;
         this.capsFrom = rc;
         this.zeroIsMax = zim;
+        this.useJTLcap = useJTLcap;
     }
 
     public int compare(SWGKnownResource r1, SWGKnownResource r2) {
-        double d1 = weights.rate(r1, capsFrom, zeroIsMax);
-        double d2 = weights.rate(r2, capsFrom, zeroIsMax);
+        double d1 = weights.rate(r1, capsFrom, zeroIsMax, useJTLcap);
+        double d2 = weights.rate(r2, capsFrom, zeroIsMax, useJTLcap);
         return Double.compare(d2, d1);
     }
 }

--- a/src/main/java/swg/gui/resources/SWGGuard.java
+++ b/src/main/java/swg/gui/resources/SWGGuard.java
@@ -8,6 +8,7 @@ import swg.crafting.resources.SWGKnownResource;
 import swg.crafting.resources.SWGResource;
 import swg.crafting.resources.SWGResourceClass;
 import swg.crafting.resources.SWGResourceFilter;
+import swg.gui.SWGFrame;
 import swg.gui.common.SWGGui;
 import swg.tools.ZString;
 
@@ -135,7 +136,7 @@ public final class SWGGuard implements
      *        range [0.0 1000.0, otherwise 0.0
      * @param doAlarm {@code true} if this guard should alert the user when a
      *        resource match this instance
-     * @param acceptNoStats {@code true} if zero-values of the rsource are
+     * @param acceptNoStats {@code true} if zero-values of the resource are
      *        accepted
      * @throws IllegalArgumentException if an argument is invalid
      * @throws NullPointerException if an argument is {@code null}
@@ -210,8 +211,11 @@ public final class SWGGuard implements
      * @return {@code true} if the resource matches {@link #limit}
      */
     private boolean acceptWeighted(SWGKnownResource r, SWGWeights w) {
+        boolean useJTLCap = ((Boolean) SWGFrame.getPrefsKeeper().get(
+                "optionUseJTLcaps", Boolean.FALSE)).booleanValue();
+
         return w.rate(r, resourceClass,
-                acceptNoStats) >= limit;
+                acceptNoStats, useJTLCap) >= limit;
     }
 
     /**

--- a/src/main/java/swg/gui/resources/SWGHarvestingTab.java
+++ b/src/main/java/swg/gui/resources/SWGHarvestingTab.java
@@ -1092,10 +1092,10 @@ final class SWGHarvestingTab extends JPanel {
                     TableCellDecorations decor) {
 
                 if (value == null) return;
-                setHorizontalAlignment(column < 11
+                setHorizontalAlignment(column < 12
                         ? SwingConstants.CENTER
                         : SwingConstants.LEADING);
-                setVerticalAlignment(column < 10 && column != 6
+                setVerticalAlignment(column < 11 && column != 6
                         ? SwingConstants.CENTER
                         : SwingConstants.TOP);
             }
@@ -1147,13 +1147,16 @@ final class SWGHarvestingTab extends JPanel {
                     zs = ZString.fz("<center>%s<br/>%s</center>",
                             kr.getName(), kr.rc().rcName());
 
-                } else if (column == 7) { // concentration
+                } else if (column == 7) { // age
+                    long age = ((Long) value).longValue();
+                    return SWGResController.dateString(age);
+                } else if (column == 8) { // concentration
                     return value;
-                } else if (column == 8) { // adjusted BER
+                } else if (column == 9) { // adjusted BER
                     return ZNumber.asText(((Double) value).doubleValue(), 1, 1);
-                } else if (column == 9) { // AER
+                } else if (column == 10) { // AER
                     return ZNumber.asText(((Double) value).doubleValue(), 1, 1);
-                } else if (column == 10) { // Hopper
+                } else if (column == 11) { // Hopper
                     String dv = dateView
                             ? ZStuff.dateTimeString(harv.getHopperFull())
                             : "";
@@ -1173,7 +1176,7 @@ final class SWGHarvestingTab extends JPanel {
                         zs = ZString.fz("<center>%1.1f %%<br/>%s</center>",
                                 value, dv);
 
-                } else if (column == 11)
+                } else if (column == 12)
                         return value;
 
                 return zs.pre("<html>", false).appnl("</html>").toString();
@@ -1181,6 +1184,7 @@ final class SWGHarvestingTab extends JPanel {
         };
         activeHarvTable.setDefaultRenderer(String.class, tc);
         activeHarvTable.setDefaultRenderer(Number.class, tc);
+        activeHarvTable.setDefaultRenderer(Long.class, tc);
         activeHarvTable.setDefaultRenderer(SWGResource.class, tc);
 
         int w = SWGGuiUtils.fontWidth(activeHarvTable, "A ssigne e", activeHarvTable.getFont()) + 5;
@@ -1189,13 +1193,15 @@ final class SWGHarvestingTab extends JPanel {
         SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 2, 3, w, 5);
         w = SWGGuiUtils.fontWidth(activeHarvTable, "0123456789012345", activeHarvTable.getFont()) + 5;
         SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 4, 6, w, 90);
-        w = SWGGuiUtils.fontWidth(activeHarvTable, "100", activeHarvTable.getFont()) + 5;
+        w = SWGGuiUtils.fontWidth(activeHarvTable, " A g e ", activeHarvTable.getFont()) + 5;
         SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 7, 7, w, 5);
+        w = SWGGuiUtils.fontWidth(activeHarvTable, "100", activeHarvTable.getFont()) + 5;
+        SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 8, 8, w, 5);
         w = SWGGuiUtils.fontWidth(activeHarvTable, "UBER", activeHarvTable.getFont()) + 5;
-        SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 8, 9, w, 5);
+        SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 9, 10, w, 5);
         w = SWGGuiUtils.fontWidth(activeHarvTable, "0123456789012345", activeHarvTable.getFont()) + 5;
-        SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 10, 10, w, 90);
-        SWGGuiUtils.tableColumnSetWidth(activeHarvTable, 11, 200, 300, 4000);
+        SWGGuiUtils.tableSetColumnWidths(activeHarvTable, 11, 11, w, 90);
+        SWGGuiUtils.tableColumnSetWidth(activeHarvTable, 12, 200, 300, 4000);
 
         activeHarvTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         activeHarvTable.setAutoCreateRowSorter(true);
@@ -1531,11 +1537,11 @@ final class SWGHarvestingTab extends JPanel {
                 if (size <= 0)
                     return; // nothing to do
 
-                // status, maint, power, hopper
+                // maint, power, hopper
                 for (int i = 0; i < size; i++) {
                     activeHarvModel.fireTableCellUpdated(i, 4);
                     activeHarvModel.fireTableCellUpdated(i, 5);
-                    activeHarvModel.fireTableCellUpdated(i, 6);
+                    activeHarvModel.fireTableCellUpdated(i, 7);
                     activeHarvModel.fireTableCellUpdated(i, 11);
                 }
             }
@@ -1736,7 +1742,7 @@ final class SWGHarvestingTab extends JPanel {
          */
         private final String[] colNames =
             { "Owner", "Updated", "Description", "Type", "Maintenance",
-                    "Power", "Resource", "%", "UBER", "AER", "Hopper", "Notes" };
+                    "Power", "Resource", "Age", "%", "UBER", "AER", "Hopper", "Notes" };
 
         /**
          * An array of column header tool tips for the table of owners.
@@ -1750,6 +1756,7 @@ final class SWGHarvestingTab extends JPanel {
                         "Remains of added amount and depletion date",
                         "Remains of added units and depletion date",
                         null,
+                        null,
                         "Concentration as read at the survey device",
                         "User Base Extraction Rate, adjusted for expertise, buff, and 50%",
                         "Actual Extraction Rate, UBER adjusted for concentration",
@@ -1761,7 +1768,7 @@ final class SWGHarvestingTab extends JPanel {
         public TableCellDecorations getCellDecor(int row, int column,
                 Object value) {
 
-            if (column < 4 || (column > 6 && column != 10))
+            if (column < 4 || (column > 7 && column != 11))
                 return null;
 
             SWGHarvester harv = activeHarvs().get(row);
@@ -1794,7 +1801,10 @@ final class SWGHarvestingTab extends JPanel {
             } else if (column == 6) { // resource
                 if (harv.getResource().isDepleted())
                     check = 2;
-            } else if (column == 10) { // hopper
+            } else if (column == 7) {
+                long l = ((Long) value).longValue();
+                return SWGResController.resourceAgeDecor(harv.getResource(), l, null);
+            } else if (column == 11) { // hopper
                 long full = harv.getHopperFull();
                 if (full < now)
                     check = 2;
@@ -1831,13 +1841,15 @@ final class SWGHarvestingTab extends JPanel {
             case 1:
             case 4:
             case 5:
-            case 7:
             case 8:
             case 9:
-            case 10: // fall through
+            case 10:
+            case 11: // fall through
                 return Number.class;
             case 6:
                 return SWGResource.class;
+            case 7:
+            	return Long.class;
             default:
                 return String.class;
             }
@@ -1877,18 +1889,20 @@ final class SWGHarvestingTab extends JPanel {
             case 6:
                 return harv.getResource();
             case 7:
-                return Integer.valueOf(harv.getConcentration());
+            	return harv.getResource().age();
             case 8:
-                return Double.valueOf(harv.ber * harv.getBerModifier());
+                return Integer.valueOf(harv.getConcentration());
             case 9:
+                return Double.valueOf(harv.ber * harv.getBerModifier());
+            case 10:
                 return Double.valueOf(harv.getAER());
-            case 10: {
+            case 11: {
                 float f = harv.getHopperUnits() / harv.getHopperCapacity();
                 f = Math.min(1.0f, f);
                 Float value = Float.valueOf(100.0f * f);
                 return value;
             }
-            case 11:
+            case 12:
                 return harv.getNotes();
             default:
                 return "ERROR";
@@ -1898,7 +1912,7 @@ final class SWGHarvestingTab extends JPanel {
         @Override
         public boolean isCellEditable(int rowIndex, int columnIndex) {
             // remember setValueAt if anything changes here
-            if (columnIndex == 4 || columnIndex == 5 || columnIndex == 11)
+            if (columnIndex == 4 || columnIndex == 5 || columnIndex == 12)
                 return true;
             return false;
         }
@@ -1908,7 +1922,7 @@ final class SWGHarvestingTab extends JPanel {
         public void setValueAt(Object value, int row, int column) {
             SWGHarvester hv = activeHarvs().get(row);
 
-            if (column == 11)
+            if (column == 12)
                 hv.setNotes((String) value);
             else {
                 try {

--- a/src/main/java/swg/gui/resources/SWGInventoryTab.java
+++ b/src/main/java/swg/gui/resources/SWGInventoryTab.java
@@ -245,6 +245,12 @@ public final class SWGInventoryTab extends JPanel {
 	private StyledLabel totVal;
 
     /**
+     * A flag to use throughout this panel to account for JTL resource
+     * capping adjustments
+     */
+	private boolean useJTLcap;
+
+    /**
      * Creates an instance of this GUI component.
      * 
      * @param resourceTab the GUI component which contains this instance
@@ -253,6 +259,8 @@ public final class SWGInventoryTab extends JPanel {
         this.resourceTab = resourceTab;
         this.frame = SWGAide.frame();
 
+        useJTLcap = ((Boolean) SWGFrame.getPrefsKeeper().get(
+                "optionUseJTLcaps", Boolean.FALSE)).booleanValue();
         helpPage = SWGAide.class.getResource(
                 "docs/help_resources_inventory_en.html");
 
@@ -2470,6 +2478,16 @@ public final class SWGInventoryTab extends JPanel {
     }
 
     /**
+     * A help method to set the internal flag and redraw the UI
+     *
+     * @param useJTLcap
+     */
+    void updateJTLcap(boolean useJTLcap) {
+    	this.useJTLcap = useJTLcap;
+    	updateDisplay();
+    }
+    
+    /**
      * Helper method which updates SWGAide's status bar. This method executes on
      * a worker thread.
      */
@@ -2626,7 +2644,7 @@ public final class SWGInventoryTab extends JPanel {
             comp = new Comparator<SWGInventoryWrapper>() {
                 
                 final SWGWeightComparator cmp = new SWGWeightComparator(
-                        (SWGWeights) filter, resourceClass, true);
+                        (SWGWeights) filter, resourceClass, true, useJTLcap);
 
                 @Override
                 public int compare(
@@ -2675,8 +2693,8 @@ public final class SWGInventoryTab extends JPanel {
 
                     public int compare(SWGInventoryWrapper w1,
                             SWGInventoryWrapper w2) {
-                        double d1 = wgt.rate(w1.getResource(), cls, true);
-                        double d2 = wgt.rate(w2.getResource(), cls, true);
+                        double d1 = wgt.rate(w1.getResource(), cls, true, useJTLcap);
+                        double d2 = wgt.rate(w2.getResource(), cls, true, useJTLcap);
                         return Double.compare(d1, d2);
                     }
                 };
@@ -2846,7 +2864,7 @@ public final class SWGInventoryTab extends JPanel {
                         ? resourceClass
                         : kr.rc();
 
-                double rating = weights.rate(kr, cap, true);
+                double rating = weights.rate(kr, cap, true, useJTLcap);
                 return Double.valueOf(rating);
             }
             case 18:

--- a/src/main/java/swg/gui/resources/SWGResController.java
+++ b/src/main/java/swg/gui/resources/SWGResController.java
@@ -442,11 +442,19 @@ public final class SWGResController implements UpdateSubscriber {
      * and active monitors. The other entry point is {@code check(boolean)}.
      */
     public void handleUpdate(UpdateNotification u) {
-        ResourceUpdate uu = (ResourceUpdate) u;
-
-        // This method dispatches to its helper method on every call, see the
-        // class JDocu comments
-        check((SWGCGalaxy) uu.optional);
+    	if (u instanceof ResourceUpdate) {
+            // This method dispatches to its helper method on every call, see the
+            // class JDocu comments
+            ResourceUpdate ru = (ResourceUpdate) u;
+            switch (ru.type) {
+			case LOCAL_SUBMISSION:
+			case NEW_DOWNLOAD:
+	            check((SWGCGalaxy) ru.optional);
+	            break;
+			default:
+				break;
+            }
+    	}
     }
 
     /**
@@ -2332,11 +2340,12 @@ public final class SWGResController implements UpdateSubscriber {
      * @param w a weights object
      * @param spawn a set of spawning resources
      * @param inv a list of inventory resources
+     * @param useJTLcap a flag to adjust for JTL resource capping rules
      * @return a sorted set of resources
      */
     public static SWGResourceSet resources(
             final SWGResourceClass rc, final SWGWeights w,
-            SWGResourceSet spawn, List<SWGInventoryWrapper> inv) {
+            SWGResourceSet spawn, List<SWGInventoryWrapper> inv, boolean useJTLcap) {
 
         SWGResourceSet res = new SWGResourceSet(128);
         Class<? extends SWGResourceClass> crc = rc.getClass();
@@ -2365,10 +2374,10 @@ public final class SWGResController implements UpdateSubscriber {
 
                 double w1 = o1.rc().isSpaceOrRecycled()
                         ? o1.stats().value(Stat.OQ)
-                        : w.rate(o1, rc1, hq);
+                        : w.rate(o1, rc1, hq, useJTLcap);
                 double w2 = o2.rc().isSpaceOrRecycled()
                         ? o2.stats().value(Stat.OQ)
-                        : w.rate(o2, rc2, hq);
+                        : w.rate(o2, rc2, hq, useJTLcap);
 
                 int ret = Double.compare(w1, w2);
                 return w == SWGWeights.LQ_WEIGHTS

--- a/src/main/java/swg/gui/resources/SWGResourceTab.java
+++ b/src/main/java/swg/gui/resources/SWGResourceTab.java
@@ -456,20 +456,34 @@ public final class SWGResourceTab extends JTabbedPane implements
     }
 
     public void handleUpdate(UpdateNotification u) {
-        final SWGCGalaxy gxy = (SWGCGalaxy) ((ResourceUpdate) u).optional;
-        if (isGuiFinished && gxy == galaxy()) {
+    	if (u instanceof ResourceUpdate) {
+            ResourceUpdate ru = (ResourceUpdate) u;
+            switch (ru.type) {
+			case LOCAL_SUBMISSION:
+			case NEW_DOWNLOAD:
+	    		final SWGCGalaxy gxy = (SWGCGalaxy) ru.optional;
+	            if (isGuiFinished && gxy == galaxy()) {
 
-            SwingUtilities.invokeLater(new Runnable() {
+	                SwingUtilities.invokeLater(new Runnable() {
 
-                
-                public void run() {
-                    galaxyUpdated(gxy);
-                    currentUpdateGUI();
-                    currentSend();
-                }
-            });
-        }
-        SWGDepletedTab.writeAuto(gxy); // always
+	                    
+	                    public void run() {
+	                        galaxyUpdated(gxy);
+	                        currentUpdateGUI();
+	                        currentSend();
+	                    }
+	                });
+	            }
+	            SWGDepletedTab.writeAuto(gxy); // always
+				break;
+			case JTL_RESOURCE_CAP:
+				if (isGuiFinished) {
+					inventoryTab.updateJTLcap((boolean)ru.optional);
+					currentResourcesTab.updateJTLcap((boolean)ru.optional);
+				}
+				break;
+    		}
+    	}
     }
 
     /**

--- a/src/main/java/swg/gui/schematics/SWGExperimentWrapper.java
+++ b/src/main/java/swg/gui/schematics/SWGExperimentWrapper.java
@@ -156,11 +156,11 @@ public final class SWGExperimentWrapper implements SWGGui {
      * 
      * @param spawn a set of spawning resources
      * @param inv a list of inventory resources
+     * @param useJTLcap a flag to adjust for JTL resource capping rules
      */
     private synchronized void refresh(
-            SWGResourceSet spawn, List<SWGInventoryWrapper> inv) {
-
-        resources = SWGResController.resources(resClass, weights, spawn, inv);
+            SWGResourceSet spawn, List<SWGInventoryWrapper> inv, boolean useJTLcap) {
+        resources = SWGResController.resources(resClass, weights, spawn, inv, useJTLcap);
     }
 
     /**
@@ -444,13 +444,14 @@ public final class SWGExperimentWrapper implements SWGGui {
      * @param expWrappers instances of this type
      * @param spawn a set of resource currently in spawn
      * @param inv a set of resources inventory resources
+     * @param useJTLcap a flag to adjust for JTL resource capping rules
      * @throws NullPointerException if an argument is {@code null}
      */
     static void refresh(List<SWGExperimentWrapper> expWrappers,
-            SWGResourceSet spawn, List<SWGInventoryWrapper> inv) {
+            SWGResourceSet spawn, List<SWGInventoryWrapper> inv, boolean useJTLcap) {
 
         for (SWGExperimentWrapper ew : expWrappers)
-            ew.refresh(spawn, inv);
+            ew.refresh(spawn, inv, useJTLcap);
     }
 
     /**

--- a/src/main/java/swg/gui/schematics/SWGRCWPair.java
+++ b/src/main/java/swg/gui/schematics/SWGRCWPair.java
@@ -187,16 +187,17 @@ final class SWGRCWPair implements Comparable<SWGRCWPair> {
      * returns the response from {@link SWGRCWPair#compareTo(SWGRCWPair)}.
      * 
      * @param kr a known resource, not {@code null}
+     * @param useJTLcap a flag to adjust for JTL resource capping rules
      * @return a comparator
      */
-    public static Comparator<SWGRCWPair> comparator(final SWGKnownResource kr) {
+    public static Comparator<SWGRCWPair> comparator(final SWGKnownResource kr, boolean useJTLcap) {
         return new Comparator<SWGRCWPair>() {
             @Override
             public int compare(SWGRCWPair r1, SWGRCWPair r2) {
                 SWGWeights wg1 = (SWGWeights) r1.filter();
                 SWGWeights wg2 = (SWGWeights) r2.filter();
-                double w1 = wg1.rate(kr, r1.rc(), true);
-                double w2 = wg2.rate(kr, r2.rc(), true);
+                double w1 = wg1.rate(kr, r1.rc(), true, useJTLcap);
+                double w2 = wg2.rate(kr, r2.rc(), true, useJTLcap);
                 int c = Double.compare(w2, w1); // reversed order, best first
                 return c != 0
                         ? c

--- a/src/main/java/swg/gui/schematics/SWGSchemController.java
+++ b/src/main/java/swg/gui/schematics/SWGSchemController.java
@@ -492,10 +492,11 @@ final public class SWGSchemController implements UpdateSubscriber {
      * @param kr a resource
      * @param limit the minimum rate for inclusion
      * @param creature {@code true} to include creature for Organic
+     * @#param useJTLcap {@code true} to adjust for JTL resource capping rules
      * @return a sorted list of HQ schematics
      */
     List<SWGSac> schematics(
-            final SWGKnownResource kr, double limit, boolean creature, SWGCGalaxy gxy) {
+            final SWGKnownResource kr, double limit, boolean creature, boolean useJTLcap, SWGCGalaxy gxy) {
 
         List<SWGRCWPair> rl = rcwPairs(kr.rc(), true, gxy);
         if (rl.isEmpty()) return Collections.emptyList();
@@ -506,13 +507,13 @@ final public class SWGSchemController implements UpdateSubscriber {
                     iter.remove();
 
         // sort rcw-pairs on rate before iterating over schematics, best first
-        Collections.sort(rl, SWGRCWPair.comparator(kr));
+        Collections.sort(rl, SWGRCWPair.comparator(kr, useJTLcap));
         Collections.sort(rl, SWGRCWPair.comparatorRC(true));
 
         List<SWGSac> ret = new ArrayList<SWGSac>(rl.size());
         Object ex = new Object();
         for (SWGRCWPair r : rl) {
-            double w = ((SWGWeights) r.filter()).rate(kr, r.rc(), true);
+            double w = ((SWGWeights) r.filter()).rate(kr, r.rc(), true, useJTLcap);
             if (w < limit) continue;
 
             for (SWGSchematic s : r.schematics()) {

--- a/src/main/java/swg/gui/schematics/SWGSchemResViewer.java
+++ b/src/main/java/swg/gui/schematics/SWGSchemResViewer.java
@@ -190,6 +190,12 @@ public final class SWGSchemResViewer extends SWGJDialog {
     private SWGJTable schemTable;
 
     /**
+     * A flag to use throughout this panel to account for JTL resource
+     * capping adjustments
+     */
+    private boolean useJTLcap = false;
+
+    /**
      * Creates a mode-less dialog of this type.
      */
     private SWGSchemResViewer(SWGFrame fr) {
@@ -335,7 +341,7 @@ public final class SWGSchemResViewer extends SWGJDialog {
 
                 SWGSchematicWrapper w = SWGSchemController.wrapperDefault(s);
                 SWGExperimentWrapper.refresh(w.experiments(),
-                        SWGSchemController.spawning(), il);
+                        SWGSchemController.spawning(), il, useJTLcap);
 
                 SWGResourceSet rs = new SWGResourceSet();
                 for (SWGExperimentWrapper ew : w.experiments())
@@ -350,7 +356,7 @@ public final class SWGSchemResViewer extends SWGJDialog {
                         continue;
 
                     double r = ((SWGWeights)
-                            rcw.filter()).rate(kr, rcw.rc(), true);
+                            rcw.filter()).rate(kr, rcw.rc(), true, useJTLcap);
                     if (r >= rateLimit) {
                         long inv = SWGResController.inventoryAmount(kr, gxy);
                         Long l = inv > 0
@@ -412,6 +418,9 @@ public final class SWGSchemResViewer extends SWGJDialog {
     private void display(SWGKnownResource kr, SWGFrame fr) {
     	this.frame = fr;
     	this.schemTab = SWGFrame.getSchematicTab(fr);
+        this.useJTLcap = ((Boolean) SWGFrame.getPrefsKeeper().get(
+                "optionUseJTLcaps", Boolean.FALSE)).booleanValue();
+
     	SWGCGalaxy gxy = SWGFrame.getSelectedGalaxy();
     	if(galaxy == null) {
     		galaxy = gxy;
@@ -425,7 +434,7 @@ public final class SWGSchemResViewer extends SWGJDialog {
         currentRes = kr;
         
         SWGSchemController sc = new SWGSchemController(schemTab);
-        schematics = sc.schematics(kr, rateLimit, true, gxy);
+        schematics = sc.schematics(kr, rateLimit, true, useJTLcap, gxy);
 
         if (namedLQ.isSelected())
             schematics.addAll(0, sc.schematicsLQNamed(kr));

--- a/src/main/java/swg/gui/schematics/SWGSchematicTab.java
+++ b/src/main/java/swg/gui/schematics/SWGSchematicTab.java
@@ -369,6 +369,8 @@ public final class SWGSchematicTab extends JTabbedPane {
         assigneeMenuItem = assigneeMenu();
 
         SWGResourceManager.addSubscriber(controller);
+        SWGResourceManager.addSubscriber(laboratory);
+        SWGResourceManager.addSubscriber(todaysAlert);
 
         isGuiFinished = true;
     }

--- a/src/main/java/swg/swgcraft/SWGCraftOptionsPanel.java
+++ b/src/main/java/swg/swgcraft/SWGCraftOptionsPanel.java
@@ -28,6 +28,8 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
 import swg.SWGAide;
+import swg.crafting.resources.ResourceUpdate;
+import swg.crafting.resources.ResourceUpdate.UpdateType;
 import swg.gui.SWGFrame;
 import swg.gui.common.SWGGuiUtils;
 import swg.gui.common.SWGHelp;
@@ -52,6 +54,12 @@ public class SWGCraftOptionsPanel extends JDialog {
      */
     private JCheckBox autoUpdateGalaxyResources;
 
+    /**
+     * The GUI for the check-box to propagate the usage of JTL resource capping
+     * rules throughout the app
+     */
+    private JCheckBox useJTLResourceCaps;
+    
     /**
      * A GUI list of galaxies from which to select one main galaxy.
      */
@@ -217,7 +225,7 @@ public class SWGCraftOptionsPanel extends JDialog {
 
         value = value.substring(0, value.indexOf(' '));
         value = value.replace("+", "");
-        value = value.replace("½", ".5");
+        value = value.replace("ï¿½", ".5");
         Double zon = Double.parseDouble(value);
         SWGFrame.getPrefsKeeper().add("optionTimeZoneValue", zon);
     }
@@ -316,9 +324,9 @@ public class SWGCraftOptionsPanel extends JDialog {
         vec.add("-6 (CST) [MDT]");
         vec.add("-5 (EST) [CDT]");
         vec.add("-4 (AST) [EDT]");
-        vec.add("-3½ (NST)");
+        vec.add("-3ï¿½ (NST)");
         vec.add("-3 [ADT]");
-        vec.add("-2½ [NDT]");
+        vec.add("-2ï¿½ [NDT]");
         vec.add("-2 (AT)");
         vec.add("-1 (WAT)");
         vec.add("0 GMT, UTC (WET)");
@@ -327,16 +335,16 @@ public class SWGCraftOptionsPanel extends JDialog {
         vec.add("+3 (BT, ZP3) [EEDT]");
         vec.add("+4 (ZP4)");
         vec.add("+5 (ZP5)");
-        vec.add("+5½ (IST)");
+        vec.add("+5ï¿½ (IST)");
         vec.add("+6 (ZP6)");
         vec.add("+7 (CXT, ZP7)");
         vec.add("+8 (CCT, WST, ZP8) [WADT]");
         vec.add("+9 (JST, ZP9)");
-        vec.add("+9½ [ACST]");
+        vec.add("+9ï¿½ [ACST]");
         vec.add("+10 (EST, GST, ZP10)");
-        vec.add("+10½ [ACDT]");
+        vec.add("+10ï¿½ [ACDT]");
         vec.add("+11 [EADT]");
-        vec.add("+11½ (NFT)");
+        vec.add("+11ï¿½ (NFT)");
         vec.add("+12 (IDLE, NZT)");
         vec.add("+13 [NZDT]");
         vec.add("offset (standard time) [daylight time]");
@@ -366,6 +374,8 @@ public class SWGCraftOptionsPanel extends JDialog {
         galaxyList.setSelectedItem(glx);
         glxPanel.add(galaxyList);
 
+        
+        Box vertBox = Box.createVerticalBox();
         autoUpdateGalaxyResources = new JCheckBox("Auto-update");
         autoUpdateGalaxyResources
             .setToolTipText("Automatically download resource statistics "
@@ -379,8 +389,27 @@ public class SWGCraftOptionsPanel extends JDialog {
                 actionAutoUpdateGalaxyToggled();
             }
         });
-        glxPanel.add(autoUpdateGalaxyResources);
+        vertBox.add(autoUpdateGalaxyResources);
 
+        
+        useJTLResourceCaps = new JCheckBox("JTL Resource Caps");
+        useJTLResourceCaps.setToolTipText("Use JTL Resource Cap Rules for weights and schematics experimentation");
+        useJTLResourceCaps.addActionListener(new ActionListener() {
+            
+            @Override
+            public void actionPerformed(ActionEvent e) {
+            	boolean jtlCheckState = useJTLResourceCaps.isSelected();
+                SWGFrame.getPrefsKeeper().add("optionUseJTLcaps",
+                        Boolean.valueOf(jtlCheckState));
+                SWGResourceManager.notifySubscribers(new ResourceUpdate(
+                        UpdateType.JTL_RESOURCE_CAP, jtlCheckState));
+            }
+        });
+        useJTLResourceCaps.setSelected(((Boolean) SWGFrame.getPrefsKeeper().get(
+                        "optionUseJTLcaps", Boolean.FALSE)).booleanValue());
+        vertBox.add(useJTLResourceCaps);
+        
+        glxPanel.add(vertBox);
         glxPanel.add(Box.createGlue());
 
         return glxPanel;


### PR DESCRIPTION
This update includes code to support servers that observe the different caps for JTL resources. By default, this is set to false, so most users won't have to worry about setting it. For those on servers that use this different resource capping rule, users can set this option to true in the Options menu.