### PR TITLE
Fixing integer math related to calculating hopper percentage full.

### DIFF
--- a/src/main/java/swg/gui/resources/SWGHarvestingTab.java
+++ b/src/main/java/swg/gui/resources/SWGHarvestingTab.java
@@ -1897,9 +1897,9 @@ final class SWGHarvestingTab extends JPanel {
             case 10:
                 return Double.valueOf(harv.getAER());
             case 11: {
-                float f = harv.getHopperUnits() / harv.getHopperCapacity();
+                float f = Float.valueOf(harv.getHopperUnits()) / Float.valueOf(harv.getHopperCapacity());
                 f = Math.min(1.0f, f);
-                Float value = Float.valueOf(100.0f * f);
+                Float value = 100.0f * f;
                 return value;
             }
             case 12:


### PR DESCRIPTION
The previous calculation was taking the result of two integer-based methods and dividing them. Because the divisor was almost always larger, it would result in 0. 