### PR TITLE
Fixing issue where the hopper was always remaining full

### DIFF
--- a/src/main/java/swg/gui/resources/SWGHarvester.java
+++ b/src/main/java/swg/gui/resources/SWGHarvester.java
@@ -843,6 +843,7 @@ public final class SWGHarvester implements Serializable, Comparable<SWGHarvester
      */
     void refreshHopperEmptied() {
     	hopperEmptied = System.currentTimeMillis();
+    	hopperFull = false;
     }
 
     /**


### PR DESCRIPTION
Setting the hopperFull property to false upon using the "empty hopper" feature.